### PR TITLE
Refactor/structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,32 @@ ReactDom.render(
 );
 ```
 
+### Setting a custom className
+
+The `div` Card wrapper has a default `sui-Card` class.
+You can override it defining a custom class by setting the `proptype` `className` as follows:
+
+```javascript
+ReactDom.render(
+    <SuiCard className={'myCustom-class'}
+      primary={[
+        <a href={data.link}><img src={data.src} /></a>
+      ]}
+      secondary={[
+        <div>
+            <h2 className='sui-Card-title'>
+            This is the Card Title
+            </h2>
+            <p className='sui-Card-description'>
+                This is the description
+            </p>
+        </div>
+      }
+    />,
+  document.getElementById('main')
+);
+```
+
 ### Card layout Orientation
 
 The default *Card* orientation is **portrait mode**.  Use the `landscapeLayout={true}` parameter to set it landscape where the `primary` placeholder aligns to the left and the `secondary` to the right:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ The SUI-Card component features a placeholder to portray a custom primary and a 
 
 ## Usage
 
-The **SUI-Card** allows to pass custom content in the primary placeholder and also provides a `sui-Card-primary` class as a wrapper.
+The **SUI-Card** allows to pass custom content in the primary placeholder and also provides a `sui-Card-primary` class as a wrapper. This primary content **is required**.
+
+Secondary content might be passed or not to SuiCard component. If content is provided will be rendered inside a generic *div* `sui-Card-secondary` wrapper.
+If no content is provided this contained will not be rendered at all.
 
 Check out this example below
 ```javascript
@@ -17,7 +20,7 @@ Check out this example below
 ReactDom.render(
     <SuiCard
       primary={[
-        <SuiMultimedia data={data} />
+        <a href={data.link}><img src={data.src} /></a>
       ]}
       secondary={[
         <div>
@@ -43,7 +46,7 @@ The default *Card* orientation is **portrait mode**.  Use the `landscapeLayout={
 ReactDom.render(
     <SuiCard landscapeLayout
       primary={[
-        <SuiMultimedia data={data} />
+        <a href={data.link}><img src={data.src} /></a>
       ]}
       secondary={[
         <div>
@@ -70,7 +73,7 @@ When `landscapeLayout={true}` you can also set secondary content placeholder ren
 ReactDom.render(
     <SuiCard landscapeLayout contentFirst
       primary={[
-        <SuiMultimedia data={data} />
+        <a href={data.link}><img src={data.src} /></a>
       ]}
       secondary={[
         <div>

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Check out this example below
 ```javascript
 
 ReactDom.render(
-    <SuiCard
-      primary={[
-        <a href={data.link}><img src={data.src} /></a>
-      ]}
+    <SuiCard className={'myCustom-class'}
+      primary={
+        <a href={images[0].link}><img src={images[0].src} /></a>
+      }
       secondary={[
         <div>
             <h2 className='sui-Card-title'>
@@ -45,9 +45,9 @@ You can override it defining a custom class by setting the `proptype` `className
 ```javascript
 ReactDom.render(
     <SuiCard className={'myCustom-class'}
-      primary={[
-        <a href={data.link}><img src={data.src} /></a>
-      ]}
+      primary={
+        <a href={images[0].link}><img src={images[0].src} /></a>
+      }
       secondary={[
         <div>
             <h2 className='sui-Card-title'>
@@ -71,9 +71,9 @@ The default *Card* orientation is **portrait mode**.  Use the `landscapeLayout={
 
 ReactDom.render(
     <SuiCard landscapeLayout
-      primary={[
-        <a href={data.link}><img src={data.src} /></a>
-      ]}
+      primary={
+        <a href={images[0].link}><img src={images[0].src} /></a>
+      }
       secondary={[
         <div>
             <h2 className='sui-Card-title'>
@@ -98,9 +98,9 @@ When `landscapeLayout={true}` you can also set secondary content placeholder ren
 
 ReactDom.render(
     <SuiCard landscapeLayout contentFirst
-      primary={[
-        <a href={data.link}><img src={data.src} /></a>
-      ]}
+      primary={
+        <a href={images[0].link}><img src={images[0].src} /></a>
+      }
       secondary={[
         <div>
           <h2 className='sui-Card-title'>
@@ -114,6 +114,19 @@ ReactDom.render(
     />,
   document.getElementById('main')
 );
+```
+
+## Data model used in this example
+
+Use an array of objects:
+
+```javascript
+const images = [{
+  src: 'https://scontent-mad1-1.cdninstagram.com/t51.2885-15/e15/11199623_633712610062793_1285693904_n.jpg',
+  type: 'image',
+  alt: 'Test',
+  link: 'https://www.instagram.com/p/TNUdPKpMgM/?taken-by=davecarter'
+}];
 ```
 
 ## Installation

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,8 +16,11 @@
 <section class="block block-usecase block--centered">
   <div class="centered-block">
 
-    <h2>SUI-Card render Example</h2>
+    <h2>SUI-Card single image render Example</h2>
     <div id="main"></div>
+
+    <h2>SUI-Card Sui-Multimedia component Example</h2>
+    <div id="main-multimedia"></div>
 
     <h2>SUI-Card Component implementation</h2>
     <div>

--- a/docs/index.jsx
+++ b/docs/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDom from 'react-dom';
 import SuiCard from '../src';
+import SuiMultimedia from '@schibstedspain/sui-multimedia';
 
 import '../src/index.scss';
 import './styles/prism.scss';
@@ -10,18 +11,18 @@ import './styles/codemirror.scss';
 import './styles/demo.scss';
 import '../node_modules/@schibstedspain/sui-multimedia/dist/_sui-multimedia.scss';
 
-const data = {
+const images = [{
   src: 'https://scontent-mad1-1.cdninstagram.com/t51.2885-15/e15/11199623_633712610062793_1285693904_n.jpg',
   type: 'image',
   alt: 'Test',
   link: 'https://www.instagram.com/p/TNUdPKpMgM/?taken-by=davecarter'
-};
+}];
 
 ReactDom.render(
     <SuiCard className={'myCustom-class'}
-      primary={[
-        <a href={data.link}><img src={data.src} /></a>
-      ]}
+      primary={
+        <a href={images[0].link}><img src={images[0].src} /></a>
+      }
       secondary={[
         <div>
           <h2 className='sui-Card-title'>This is the Card Title</h2>
@@ -30,4 +31,19 @@ ReactDom.render(
       ]}
     />,
   document.getElementById('main')
+);
+
+ReactDom.render(
+    <SuiCard className={'myCustom-class'}
+      primary={[
+        <SuiMultimedia images={images} />
+      ]}
+      secondary={[
+        <div>
+          <h2 className='sui-Card-title'>This is the Card Title</h2>
+          <p className='sui-Card-description'>This is the description text of this Card</p>
+        </div>
+      ]}
+    />,
+  document.getElementById('main-multimedia')
 );

--- a/docs/index.jsx
+++ b/docs/index.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDom from 'react-dom';
 import SuiCard from '../src';
-import SuiMultimedia from '@schibstedspain/sui-multimedia';
 
 import '../src/index.scss';
 import './styles/prism.scss';
@@ -11,16 +10,16 @@ import './styles/codemirror.scss';
 import './styles/demo.scss';
 import '../node_modules/@schibstedspain/sui-multimedia/dist/_sui-multimedia.scss';
 
-const data = [{
+const data = {
   src: 'https://scontent-mad1-1.cdninstagram.com/t51.2885-15/e15/11199623_633712610062793_1285693904_n.jpg',
   type: 'image',
   link: 'https://www.instagram.com/p/TNUdPKpMgM/?taken-by=davecarter'
-}];
+};
 
 ReactDom.render(
-    <SuiCard
+    <SuiCard customClass={'myCustom-class'}
       primary={[
-        <SuiMultimedia data={data} />
+        <a href={data.link}><img src={data.src} /></a>
       ]}
       secondary={[
         <div>

--- a/docs/index.jsx
+++ b/docs/index.jsx
@@ -18,7 +18,7 @@ const data = {
 };
 
 ReactDom.render(
-    <SuiCard customClass={'myCustom-class'}
+    <SuiCard className={'myCustom-class'}
       primary={[
         <a href={data.link}><img src={data.src} /></a>
       ]}

--- a/docs/index.scss
+++ b/docs/index.scss
@@ -1,5 +1,11 @@
 @import '~@schibstedspain/theme-basic/src/settings';
 
+.sui-Card-primary {
+  img {
+    width: 100%;
+  }
+}
+
 header {
   background-color: lightblue;
   height: 150px;

--- a/docs/index.scss
+++ b/docs/index.scss
@@ -6,6 +6,10 @@
   }
 }
 
+.myCustom-class {
+  background-color: lightgrey;
+}
+
 header {
   background-color: lightblue;
   height: 150px;

--- a/src/sui-card/index.jsx
+++ b/src/sui-card/index.jsx
@@ -6,8 +6,9 @@ class SuiCard extends React.Component {
     return {
       landscapeLayout: React.PropTypes.bool,
       contentFirst: React.PropTypes.bool,
-      primary: React.PropTypes.array,
-      secondary: React.PropTypes.array
+      primary: React.PropTypes.array.isRequired,
+      secondary: React.PropTypes.array,
+      customClass: React.PropTypes.string
     };
   }
 
@@ -18,10 +19,18 @@ class SuiCard extends React.Component {
     };
   }
 
+  secondary() {
+    return (
+      <div className='sui-Card-secondary'>
+        {this.props.secondary}
+      </div>
+    );
+  }
 
   render() {
     const classNames = cx({
       'sui-Card': true,
+      [`${this.props.customClass}`]: this.props.customClass,
       'sui-Card--landscape': this.state.landscapeLayout,
       'sui-Card--contentfirst': this.props.landscapeLayout && this.props.contentFirst
     });
@@ -31,9 +40,7 @@ class SuiCard extends React.Component {
         <div className='sui-Card-primary'>
           {this.props.primary}
         </div>
-        <div className='sui-Card-secondary'>
-          {this.props.secondary}
-        </div>
+        {this.props.secondary && this.secondary.bind()}
       </div>
     );
   }

--- a/src/sui-card/index.jsx
+++ b/src/sui-card/index.jsx
@@ -8,7 +8,7 @@ class SuiCard extends React.Component {
       contentFirst: React.PropTypes.bool,
       primary: React.PropTypes.array.isRequired,
       secondary: React.PropTypes.array,
-      customClass: React.PropTypes.string
+      className: React.PropTypes.string
     };
   }
 
@@ -19,18 +19,11 @@ class SuiCard extends React.Component {
     };
   }
 
-  secondary() {
-    return (
-      <div className='sui-Card-secondary'>
-        {this.props.secondary}
-      </div>
-    );
-  }
 
   render() {
     const classNames = cx({
-      'sui-Card': true,
-      [`${this.props.customClass}`]: this.props.customClass,
+      'sui-Card': !this.props.className,
+      [`${this.props.className}`]: this.props.className,
       'sui-Card--landscape': this.state.landscapeLayout,
       'sui-Card--contentfirst': this.props.landscapeLayout && this.props.contentFirst
     });
@@ -40,7 +33,10 @@ class SuiCard extends React.Component {
         <div className='sui-Card-primary'>
           {this.props.primary}
         </div>
-        {this.props.secondary && this.secondary.bind()}
+        {this.props.secondary &&
+          <div className='sui-Card-secondary'>
+          {this.props.secondary}
+        </div>}
       </div>
     );
   }


### PR DESCRIPTION
## PR Summary

This PR adds a custom classname to the `SuiCard` generic `div` wrapper. This feature is quite useful when many Cards are contained inside the same wrapper and needs to have different classnames each.

Is also useful when applying different Flexbox property `flex-basis` values to multiple Cards.
If any custom class is provided the container will have the default `sui-Card` class.
In addition, includes the following improvements:

- Now `primary-content`is required.
- If `secondary-content` is not provided nothing is returned
- Updated README.md file

Please review @nucliweb @kikoruiz @ruben-martin-lozano @danderu 